### PR TITLE
Fixes javascript error with SelectMultiple-widget.

### DIFF
--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -166,12 +166,11 @@ class Select(widgets.Input):
 class SelectMultiple(Select):
 
     def __init__(self, js_options=None, *args, **kwargs):
-        options = {
-            'multiple': True,
-        }
+        options = {}
         if js_options is not None:
             options.update(js_options)
         super(SelectMultiple, self).__init__(js_options=options, *args, **kwargs)
+        self.attrs.update(multiple='multiple')
 
     def _format_value(self, value):
         if isinstance(value, list):


### PR DESCRIPTION
Error: Option 'multiple' is not allowed for Select2 when attached to a <select> element.
http://127.0.0.1:8000/static/select2/js/select2.js?v=1
Line 1289

Even though the Select2 docs[1] say

   When Select2 is attached to a select element this value will be ignored and
   select's multiple attribute will be used instead.

this is not ignored, but throws an error.

[1] http://ivaynberg.github.io/select2/#documentation
