### PR TITLE
Update urls.py for Django 1.6

### DIFF
--- a/select2/urls.py
+++ b/select2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('',
     url(r'^fetch_items/(?P<app_label>[^\/]+)/(?P<model_name>[^\/]+)/(?P<field_name>[^\/]+)/$',


### PR DESCRIPTION
Simple change to urls.py to fix Django 1.6 compatibility as urls.defaults was deprecated.
