### PR TITLE
Split multiple widget values when using ajax.

### DIFF
--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -197,6 +197,7 @@ class SelectMultiple(Select):
         return super(SelectMultiple, self)._has_changed(initial, data)
 
     def value_from_datadict(self, data, files, name):
-        if isinstance(data, (MultiValueDict, MergeDict)):
+        # Since ajax widgets use hidden or text input fields, when using ajax the value needs to be a string.
+        if not self.ajax and isinstance(data, (MultiValueDict, MergeDict)):
             return data.getlist(name)
         return data.get(name, None)


### PR DESCRIPTION
The recent fixes\* to the multiple widget did not take into account that they use hidden input fields, and therefore the form value will be a string separated by commas.

This commit alters the behaviour so a list is only returned if ajax is not used, if ajax is used it will return a string which is split in the clean method.

*The fixes were in  commits 784cdab959e1401038a203ba921c54cd4abc406d & b4c633ec50d10c64058a74355552dfc93405e790
