### PR TITLE
renamed mimetype to content_type in line with Django 1.7

### DIFF
--- a/select2/views.py
+++ b/select2/views.py
@@ -21,16 +21,16 @@ class JsonResponse(HttpResponse):
 
     callback = None
 
-    def __init__(self, content='', callback=None, mimetype="application/json", *args, **kwargs):
+    def __init__(self, content='', callback=None, content_type="application/json", *args, **kwargs):
         if not isinstance(content, basestring):
             content = json.dumps(content)
         if callback is not None:
             self.callback = callback
         if self.callback is not None:
             content = u"%s(\n%s\n)" % (self.callback, content)
-            mimetype = "text/javascript"
+            content_type= "text/javascript"
         return super(JsonResponse, self).__init__(content=content,
-            mimetype=mimetype, *args, **kwargs)
+            content_type=content_type, *args, **kwargs)
 
 
 class Select2View(object):


### PR DESCRIPTION
In applying django-select2-forms on a django 1.7 app I came accross this break since HttpResponse is now using content_type instead of mimetype.

Apparently there's a stock JsonResponse now in django.http, but this was my "get it working" change.