### PR TITLE
fixes theatlantic/django-select2-forms#22 no auto_created

### DIFF
--- a/select2/admin.py
+++ b/select2/admin.py
@@ -1,0 +1,40 @@
+from django.contrib.admin import widgets
+from django.forms.widgets import CheckboxSelectMultiple, SelectMultiple
+
+from .models.base import SortableThroughModel
+
+class WithSortableThroughTableModelAdminMixin(object):
+    def formfield_for_manytomany(self, db_field, request=None, **kwargs):
+        """
+        Get a form Field for a ManyToManyField.
+        """
+        # If it uses an intermediary model that isn't auto created and this is
+        # not a subclass of SortableThroughModel, don't show
+        # a field in admin.
+
+        if not issubclass(db_field.rel.through, SortableThroughModel) \
+                and not db_field.rel.through._meta.auto_created:
+            return None
+        db = kwargs.get('using')
+
+        if db_field.name in self.raw_id_fields:
+            kwargs['widget'] = widgets.ManyToManyRawIdWidget(db_field.rel,
+                                    self.admin_site, using=db)
+            kwargs['help_text'] = ''
+        elif db_field.name in (list(self.filter_vertical) + list(self.filter_horizontal)):
+            kwargs['widget'] = widgets.FilteredSelectMultiple(
+                db_field.verbose_name,
+                db_field.name in self.filter_vertical
+            )
+
+        if 'queryset' not in kwargs:
+            queryset = self.get_field_queryset(db, db_field, request)
+            if queryset is not None:
+                kwargs['queryset'] = queryset
+
+        form_field = db_field.formfield(**kwargs)
+        if isinstance(form_field.widget, SelectMultiple) and not isinstance(form_field.widget, CheckboxSelectMultiple):
+            msg = _('Hold down "Control", or "Command" on a Mac, to select more than one.')
+            help_text = form_field.help_text
+            form_field.help_text = string_concat(help_text, ' ', msg) if help_text else msg
+        return form_field

--- a/select2/models/base.py
+++ b/select2/models/base.py
@@ -12,12 +12,6 @@ from django.utils.functional import SimpleLazyObject
 
 
 class SortableThroughModelBase(ModelBase):
-    """
-    This model meta class sets Meta.auto_created to point to the model class
-    which tricks django into thinking that a custom M2M through-table was
-    auto-created by the ORM.
-    """
-
     def __new__(cls, name, bases, attrs):
         # This is the super __new__ of the parent class. If we directly
         # call the parent class we'll register the model, which we don't
@@ -45,29 +39,6 @@ class SortableThroughModelBase(ModelBase):
             class Meta: pass
             meta = Meta
             meta.__module__ = module
-
-        # Determine the app_label. We need it to call get_model()
-        app_label = getattr(meta, 'app_label', None)
-        if not app_label:
-            # All of this logic is from the parent class
-            module = attrs.get('__module__')
-            new_class = base_super_new(cls, name, bases, {'__module__': module})
-            model_module = sys.modules[new_class.__module__]
-            app_label = model_module.__name__.split('.')[0]
-
-        # Create a callbable using closure variables that returns
-        # get_model() for this model
-        def _get_model():
-            try:
-                return get_model(app_label, name, False)
-            except TypeError:
-                # Django 1.7+
-                return get_model(app_label, name)
-        # Pass the callable to SimpleLazyObject
-        lazy_model = SimpleLazyObject(_get_model)
-        # And set the auto_created to a lazy-loaded model object
-        # of the class currently being created
-        setattr(meta, 'auto_created', lazy_model)
 
         attrs['Meta'] = meta
 

--- a/select2/models/base.py
+++ b/select2/models/base.py
@@ -53,7 +53,7 @@ class SortableThroughModelBase(ModelBase):
             module = attrs.get('__module__')
             new_class = base_super_new(cls, name, bases, {'__module__': module})
             model_module = sys.modules[new_class.__module__]
-            app_label = model_module.__name__.split('.')[-2]
+            app_label = model_module.__name__.split('.')[0]
 
         # Create a callbable using closure variables that returns
         # get_model() for this model


### PR DESCRIPTION
fixes theatlantic/django-select2-forms#22
With the provided Mixin we don't need to set auto_created. 

Admin classes that have a M2M with a SortableThroughTable must inherit this mixin.