### PR TITLE
Making this project compatible with django 1.9 

### DIFF
--- a/select2/models/descriptors.py
+++ b/select2/models/descriptors.py
@@ -1,11 +1,11 @@
 import django
 from django.db import router
 from django.db.models import signals
-from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor
+from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
 from ..utils import cached_property
 
 
-class SortableReverseManyRelatedObjectsDescriptor(ReverseManyRelatedObjectsDescriptor):
+class SortableReverseManyRelatedObjectsDescriptor(ReverseManyToOneDescriptor):
 
     @cached_property
     def related_manager_cls(self):

--- a/select2/models/descriptors.py
+++ b/select2/models/descriptors.py
@@ -4,7 +4,7 @@ from django.db.models import signals
 try:
     from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor as ReverseManyToOneDescriptor
 except ImportError:
-    from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
+    from django.db.models.fields.related import ReverseManyToOneDescriptor
 from ..utils import cached_property
 
 

--- a/select2/models/descriptors.py
+++ b/select2/models/descriptors.py
@@ -1,7 +1,10 @@
 import django
 from django.db import router
 from django.db.models import signals
-from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
+try:
+    from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor as ReverseManyToOneDescriptor
+except ImportError:
+    from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
 from ..utils import cached_property
 
 

--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -9,7 +9,7 @@ try:
     from django.forms.utils import flatatt
 except ImportError:
     from django.forms.util import flatatt
-from django.utils.datastructures import MultiValueDict, MergeDict
+from django.utils.datastructures import MultiValueDict
 from django.utils.html import escape, conditional_escape
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
@@ -205,6 +205,6 @@ class SelectMultiple(Select):
 
     def value_from_datadict(self, data, files, name):
         # Since ajax widgets use hidden or text input fields, when using ajax the value needs to be a string.
-        if not self.ajax and isinstance(data, (MultiValueDict, MergeDict)):
+        if not self.ajax and isinstance(data, (MultiValueDict)):
             return data.getlist(name)
         return data.get(name, None)

--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -10,6 +10,11 @@ try:
 except ImportError:
     from django.forms.util import flatatt
 from django.utils.datastructures import MultiValueDict
+try:
+        from django.utils.datastructures import MergeDict
+except ImportError:
+        MergeDict = type('MergeDict', (object, ), {})
+
 from django.utils.html import escape, conditional_escape
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
@@ -205,6 +210,6 @@ class SelectMultiple(Select):
 
     def value_from_datadict(self, data, files, name):
         # Since ajax widgets use hidden or text input fields, when using ajax the value needs to be a string.
-        if not self.ajax and isinstance(data, (MultiValueDict)):
+        if not self.ajax and isinstance(data, (MultiValueDict, MergeDict)):
             return data.getlist(name)
         return data.get(name, None)

--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -11,9 +11,9 @@ except ImportError:
     from django.forms.util import flatatt
 from django.utils.datastructures import MultiValueDict
 try:
-        from django.utils.datastructures import MergeDict
+    from django.utils.datastructures import MergeDict
 except ImportError:
-        MergeDict = type('MergeDict', (object, ), {})
+    MergeDict = type('MergeDict', (object, ), {})
 
 from django.utils.html import escape, conditional_escape
 from django.utils.encoding import force_unicode


### PR DESCRIPTION
I am making this pull request mostly to document what I did to make my fork compatible with django 1.9

As per the release notes for Django 1.9 - the  
```from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor ```
has been moved to:
``` from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor ```

Also, ```MergeDict``` has been removed.  I doubt you can accept this pull request as is, as it does nothing to support older code - but I'm happy to update it to better support both if you are willing to accept it. 

The easiest way that I've thought of is to make both imports try the old way, switch to the new way. and to make the tuple that's passed into the isinstance call be set based on which import works. 

Something like:
```
try: 
    from django.db.models.fields.related import ReverseManyRelatedObjectsDescriptor
except ImportError:
    from django.db.models.fields.related_descriptors import ReverseManyToOneDescriptor
```
and
```
try:
    from django.utils.datastructures import MultiValueDict, MergeDict
    dict_instance_types = (MultiValueDict, MergeDict)
except ImportError:
    from django.utils.datastructures import MultiValueDict
    dict_instance_types = (MultiValueDict,)
```
