### PR TITLE
dj22: Fix TypeError in render method kwargs, add jquery.init.js to media

### DIFF
--- a/select2/widgets.py
+++ b/select2/widgets.py
@@ -23,6 +23,7 @@ class Select(widgets.Input):
 
     class Media:
         js = (
+            "admin/js/jquery.init.js",
             "select2/js/select2.jquery_ready.js",
             "select2/js/select2.jquery_ui_sortable.js",
             "select2/js/select2.js",
@@ -96,7 +97,7 @@ class Select(widgets.Input):
             "text": force_text(option_label),
         }
 
-    def render(self, name, value, attrs=None, choices=(), js_options=None):
+    def render(self, name, value, attrs=None, choices=(), js_options=None, **kwargs):
         options = {}
         attrs = dict(self.attrs, **(attrs or {}))
         js_options = js_options or {}


### PR DESCRIPTION
Starting in Django 2.1 `Widget.render` is passed `renderer` as a keyword argument. I've updated the render method in this library to prevent a TypeError in Django 2.1+.

For the change to media, see the [Merging of form `Media` assets](https://docs.djangoproject.com/en/3.1/releases/2.2/#merging-of-form-media-assets)  section in the Django 2.2 release notes:

> Form `Media` assets are now merged using a topological sort algorithm, as the old pairwise merging algorithm is insufficient for some cases. CSS and JavaScript files which don’t include their dependencies may now be sorted incorrectly (where the old algorithm produced results correctly by coincidence).
>
> Audit all `Media` classes for any missing dependencies. For example, widgets depending on `django.jQuery` must specify `js=['admin/js/jquery.init.js', ...]` when declaring form media assets.