### PR TITLE
chore(gha): Update 3rd party actions due to set-output deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = pytest {posargs}
 deps =
     pytest>=5.2.0
     pytest-django
-    selenium
+    selenium==3.141.0
     django-selenosis
     django22: Django>=2.2,<3.0
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
Update the versions used of some 3rd party GitHub Actions we use to silance the set-output deprication warnings and prevent workflows from [breaking in March 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)