### PR TITLE
Fix select2 for newer django versions

### DIFF
--- a/select2/fields.py
+++ b/select2/fields.py
@@ -133,12 +133,11 @@ class Select2ModelFieldMixin(Select2FieldMixin):
         self.choice_iterator_cls = kwargs.pop('choice_iterator_cls', self.choice_iterator_cls)
         super(Select2ModelFieldMixin, self).__init__(*args, **kwargs)
 
-    def _get_choices(self):
+    @Select2FieldMixin.choices.getter
+    def choices(self):
         if hasattr(self, '_choices'):
             return self._choices
         return self.choice_iterator_cls(self)
-
-    choices = property(_get_choices, forms.ChoiceField._set_choices)
 
 
 class ModelChoiceField(Select2ModelFieldMixin, forms.ModelChoiceField):


### PR DESCRIPTION
```
  File "/Users/x/Desktop/WorkSpace/TSP/TSP-evaluations/questionnaires/models/misc.py", line 9, in <module>
    import select2.fields
  File "/Users/x/.pyenv/versions/3.12.2/lib/python3.12/site-packages/select2/fields.py", line 117, in <module>
    class Select2ModelFieldMixin(Select2FieldMixin):
  File "/Users/x/.pyenv/versions/3.12.2/lib/python3.12/site-packages/select2/fields.py", line 141, in Select2ModelFieldMixin
    choices = property(_get_choices, forms.ChoiceField._set_choices)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'ChoiceField' has no attribute '_set_choices'
```